### PR TITLE
Dev Ops 4174981 Accessibility: yoast_breadcrumb Update for Theme

### DIFF
--- a/wp-content/themes/wp-shield/page-templates/basic-page.php
+++ b/wp-content/themes/wp-shield/page-templates/basic-page.php
@@ -19,7 +19,7 @@ $add_breadcrumbs = get_post_meta( $post->ID, 'add_breadcrumbs', true );
 	<?php 
 		if ($banner_design == 'basic-page' ){
 			if ( function_exists('yoast_breadcrumb') ) { 
-				yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); 
+				yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); 
 			}
 			the_title('<h1>', '</h1>');
 		}
@@ -27,7 +27,7 @@ $add_breadcrumbs = get_post_meta( $post->ID, 'add_breadcrumbs', true );
 	<?php 
 		if ($banner_design == 'default-bleed' and $add_breadcrumbs == 'yes'){
 			if ( function_exists('yoast_breadcrumb') ) { 
-				yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); 
+				yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); 
 		}
 	}
 	?>

--- a/wp-content/themes/wp-shield/page-templates/shield-blocks.php
+++ b/wp-content/themes/wp-shield/page-templates/shield-blocks.php
@@ -10,7 +10,7 @@ $banner_design = get_post_meta( $post->ID, 'banner_design_key', true );
 	<?php 
 		if ($banner_design == 'basic-page'){
 			if ( function_exists('yoast_breadcrumb') ) { 
-				yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); 
+				yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); 
 			}
 			the_title('<h1>', '</h1>');
 		}

--- a/wp-content/themes/wp-shield/page.php
+++ b/wp-content/themes/wp-shield/page.php
@@ -19,7 +19,7 @@ $add_breadcrumbs = get_post_meta( $post->ID, 'add_breadcrumbs', true );
 	<?php 
 		if ($banner_design == 'basic-page' ){
 			if ( function_exists('yoast_breadcrumb') ) { 
-				yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); 
+				yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); 
 			}
 			the_title('<h1>', '</h1>');
 		}
@@ -27,7 +27,7 @@ $add_breadcrumbs = get_post_meta( $post->ID, 'add_breadcrumbs', true );
 	<?php 
 		if ($banner_design == 'default-bleed' and $add_breadcrumbs == 'yes'){
 			if ( function_exists('yoast_breadcrumb') ) { 
-				yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); 
+				yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); 
 		}
 	}
 	?>


### PR DESCRIPTION
This changes all the yoast_breadcrumb calls for the page calling to fix any related accessibility issues for site improve.

Changes yoast_breadcrumb calls in:

- page.php
- shield-blocks.php
- basic-page.php

New Call
`yoast_breadcrumb('<nav class="breadcrumbs" id="breadcrumbs" aria-label="Breadcrumb">','</nav><br><br>'); `

Old Call
`yoast_breadcrumb('<ul class="breadcrumbs" id="breadcrumbs">','</ul><br><br>'); `